### PR TITLE
Add slash command support

### DIFF
--- a/bin/setup-commands.js
+++ b/bin/setup-commands.js
@@ -28,21 +28,23 @@ const { Routes } = require("discord-api-types/v10");
   const application = await rest.get(Routes.oauth2CurrentApplication());
 
   const DIR = path.join(__dirname, "../dist/commands");
-  const commands = (await fs.readdir(DIR)).map((file) => {
-    const command = require(path.join(DIR, file));
-    if (command.disableSlash) return undefined;
-    const newLineIndex = command.help.indexOf("\n");
-    return ApplicationCommandManager.transformCommand({
-      name: command.name,
-      description: command.help.substring(
-        0,
-        Math.min(newLineIndex > 1 ? newLineIndex : command.help.length, 100)
-      ),
-      options: command.options,
-      defaultPermission: true,
-      type: "CHAT_INPUT",
-    });
-  }).filter(command => command !== undefined);
+  const commands = (await fs.readdir(DIR))
+    .map((file) => {
+      const command = require(path.join(DIR, file));
+      if (command.disableSlash) return undefined;
+      const newLineIndex = command.help.indexOf("\n");
+      return ApplicationCommandManager.transformCommand({
+        name: command.name,
+        description: command.help.substring(
+          0,
+          Math.min(newLineIndex > 1 ? newLineIndex : command.help.length, 100)
+        ),
+        options: command.options,
+        defaultPermission: true,
+        type: "CHAT_INPUT",
+      });
+    })
+    .filter((command) => command !== undefined);
   console.log(commands);
 
   await rest.put(Routes.applicationCommands(application.id), {

--- a/bin/setup-commands.js
+++ b/bin/setup-commands.js
@@ -30,6 +30,7 @@ const { Routes } = require("discord-api-types/v10");
   const DIR = path.join(__dirname, "../dist/commands");
   const commands = (await fs.readdir(DIR)).map((file) => {
     const command = require(path.join(DIR, file));
+    if (command.disableSlash) return undefined;
     const newLineIndex = command.help.indexOf("\n");
     return ApplicationCommandManager.transformCommand({
       name: command.name,
@@ -41,7 +42,7 @@ const { Routes } = require("discord-api-types/v10");
       defaultPermission: true,
       type: "CHAT_INPUT",
     });
-  });
+  }).filter(command => command !== undefined);
   console.log(commands);
 
   await rest.put(Routes.applicationCommands(application.id), {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.0",
       "license": "GPL-3.0",
       "dependencies": {
+        "@discordjs/collection": "^1.0",
         "@douile/bot-utilities": "^1.4",
         "discord.js-light": "^4.6",
         "gamedig": "^4.0",
@@ -65,10 +66,9 @@
       "integrity": "sha512-gpzXTvFVg7AjKVVJFH0oJGC0q0tO34iJGSHZNz9u3aqLxlD6LfxEs9wWVVikJqn9gra940oUTaPFizCkRDcEiA=="
     },
     "node_modules/@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.0.0.tgz",
+      "integrity": "sha512-nAxDQYE5dNAzEGQ7HU20sujDsG5vLowUKCEqZkKUIlrXERZFTt/60zKUj/g4+AVCGeq+pXC5hivMaNtiC+PY5Q==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -88,6 +88,16 @@
         "node-fetch": "^2.6.7",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+      "deprecated": "no longer supported",
+      "dev": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2811,10 +2821,9 @@
       }
     },
     "@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.0.0.tgz",
+      "integrity": "sha512-nAxDQYE5dNAzEGQ7HU20sujDsG5vLowUKCEqZkKUIlrXERZFTt/60zKUj/g4+AVCGeq+pXC5hivMaNtiC+PY5Q=="
     },
     "@discordjs/rest": {
       "version": "0.4.1",
@@ -2832,6 +2841,12 @@
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@discordjs/collection": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+          "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+          "dev": true
+        },
         "discord-api-types": {
           "version": "0.29.0",
           "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.29.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "discord.js-light": "^4.6",
     "gamedig": "^4.0",
     "node-fetch": "^2.6",
-    "pg": "^8.7"
+    "pg": "^8.7",
+    "@discordjs/collection": "^1.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0",

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -15,43 +15,45 @@ GNU General Public License for more details.
 
 import { PermissionResolvable } from "discord.js-light";
 
-import Message from "./structs/Message";
+import { CommandContext } from "./structs/CommandContext";
 
-export type Check = (message: Message) => boolean;
+export type Check = (context: CommandContext) => boolean;
 
-export function isAdmin(message: Message): boolean {
-  if (!message.member) return false;
-  return message.member.permissions.has(
-    message.client.config.adminFlag as PermissionResolvable
+export function isAdmin(context: CommandContext): boolean {
+  const member = context.member();
+  if (!member) return false;
+  return member.permissions.has(
+    context.client().config.adminFlag as PermissionResolvable
   );
 }
 
-export function isOwner(message: Message): boolean {
-  if (!message.guild) return false;
-  return message.guild.ownerId === message.author.id;
+export function isOwner(context: CommandContext): boolean {
+  const guild = context.guild();
+  if (!guild) return false;
+  return guild.ownerId === context.user().id;
 }
 
-export function isBotOwner(message: Message): boolean {
-  return message.client.config.owner === message.author.id;
+export function isBotOwner(context: CommandContext): boolean {
+  return context.client().config.owner === context.user().id;
 }
 
-export function isDMChannel(message: Message): boolean {
-  return message.channel.type === "DM";
+export function isDMChannel(context: CommandContext): boolean {
+  return context.channel()?.type === "DM";
 }
 
 export function combineAll(...checks: Check[]): Check {
-  return function (message: Message) {
+  return function (context: CommandContext) {
     for (const check of checks) {
-      if (!check(message)) return false;
+      if (!check(context)) return false;
     }
     return true;
   };
 }
 
 export function combineAny(...checks: Check[]): Check {
-  return function (message: Message) {
+  return function (context: CommandContext) {
     for (const check of checks) {
-      if (check(message)) return true;
+      if (check(context)) return true;
     }
     return false;
   };

--- a/src/commands/botinfo.ts
+++ b/src/commands/botinfo.ts
@@ -21,11 +21,12 @@ import { humanDuration } from "@douile/bot-utilities";
 
 import Message from "../structs/Message";
 import { EMBED_COLOR } from "../constants";
+import { CommandContext } from "../structs/CommandContext";
 
 export const name = "botinfo";
 export const help = "Output runtime information";
-export async function call(message: Message): Promise<void> {
-  const client = message.client;
+export async function call(context: CommandContext): Promise<void> {
+  const client = context.client();
 
   const memoryUsage = process.memoryUsage();
   let supportLink = "";
@@ -48,7 +49,7 @@ Memory usage: ${Math.round(memoryUsage.heapUsed / 1024)}kb/${Math.round(
 [discord.js](https://github.com/discordjs/discord.js)\n\
 [gamedig](https://github.com/gamedig/node-gamedig)`;
 
-  await message.channel.send({
+  await context.reply({
     embeds: [
       new MessageEmbed({
         title: `${Package.name} info`,
@@ -57,5 +58,6 @@ Memory usage: ${Math.round(memoryUsage.heapUsed / 1024)}kb/${Math.round(
         color: EMBED_COLOR,
       }),
     ],
+    ephemeral: true,
   });
 }

--- a/src/commands/gamelist.ts
+++ b/src/commands/gamelist.ts
@@ -18,7 +18,12 @@ import { ApplicationCommandOptionData, MessageEmbed } from "discord.js-light";
 import { gameList } from "../query";
 import { isAdmin, isDMChannel, combineAny } from "../checks";
 import { EMBED_COLOR } from "../constants";
-import { CommandContext } from "../structs/CommandContext";
+import {
+  CommandContext,
+  CommandInteractionContext,
+  MessageContext,
+} from "../structs/CommandContext";
+import { getSearch } from "../utils";
 
 export const name = "gamelist";
 export const check = combineAny(isAdmin, isDMChannel);
@@ -33,7 +38,7 @@ export const options: ApplicationCommandOptionData[] = [
 ];
 
 export async function call(context: CommandContext): Promise<void> {
-  const games = await gameList();
+  const games = gameList();
   const gameIterator = games.values();
   let embed = new MessageEmbed({ color: EMBED_COLOR });
   let embedSize = 100;
@@ -44,10 +49,7 @@ export async function call(context: CommandContext): Promise<void> {
   let field = "",
     key = gameIterator.next(),
     count = 0;
-  const regex =
-    context.options().length > 0
-      ? context.options().map((s) => new RegExp(s as string, "i"))
-      : undefined;
+  const regex = getSearch(context, options[0].name);
 
   while (!key.done) {
     const game = key.value;

--- a/src/commands/gamelist.ts
+++ b/src/commands/gamelist.ts
@@ -18,7 +18,7 @@ import { ApplicationCommandOptionData, MessageEmbed } from "discord.js-light";
 import { gameList } from "../query";
 import { isAdmin, isDMChannel, combineAny } from "../checks";
 import { EMBED_COLOR } from "../constants";
-import Message from "../structs/Message";
+import { CommandContext } from "../structs/CommandContext";
 
 export const name = "gamelist";
 export const check = combineAny(isAdmin, isDMChannel);
@@ -32,9 +32,9 @@ export const options: ApplicationCommandOptionData[] = [
   },
 ];
 
-export async function call(message: Message, parts: string[]): Promise<void> {
-  const games = await gameList(),
-    gameIterator = games.values();
+export async function call(context: CommandContext): Promise<void> {
+  const games = await gameList();
+  const gameIterator = games.values();
   let embed = new MessageEmbed({ color: EMBED_COLOR });
   let embedSize = 100;
   const embeds = [];
@@ -45,7 +45,9 @@ export async function call(message: Message, parts: string[]): Promise<void> {
     key = gameIterator.next(),
     count = 0;
   const regex =
-    parts.length > 0 ? parts.map((s) => new RegExp(s, "i")) : undefined;
+    context.options().length > 0
+      ? context.options().map((s) => new RegExp(s as string, "i"))
+      : undefined;
 
   while (!key.done) {
     const game = key.value;
@@ -84,6 +86,6 @@ export async function call(message: Message, parts: string[]): Promise<void> {
   if (field.length > 0) embed.addField("_ _", field);
   for (const e of embeds.concat(embed)) {
     e.setTitle(`${count} Available games`);
-    await message.channel.send({ embeds: [e] });
+    await context.reply({ embeds: [e], ephemeral: true });
   }
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -17,6 +17,7 @@ import { ApplicationCommandOptionData, MessageEmbed } from "discord.js-light";
 
 import { EMBED_COLOR } from "../constants";
 import { CommandContext } from "../structs/CommandContext";
+import { getSearch } from "../utils";
 
 function matchAny(text: string, search: RegExp[]): boolean {
   for (const s of search) {
@@ -37,7 +38,7 @@ export const options: ApplicationCommandOptionData[] = [
   },
 ];
 export async function call(context: CommandContext): Promise<void> {
-  const search = context.options().map((s) => new RegExp(s as string, "gi"));
+  const search = getSearch(context, options[0].name, "gi");
   if (search.length === 0) {
     await context.reply({
       embeds: [

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -15,8 +15,8 @@ GNU General Public License for more details.
 
 import { ApplicationCommandOptionData, MessageEmbed } from "discord.js-light";
 
-import Message from "../structs/Message";
 import { EMBED_COLOR } from "../constants";
+import { CommandContext } from "../structs/CommandContext";
 
 function matchAny(text: string, search: RegExp[]): boolean {
   for (const s of search) {
@@ -36,45 +36,50 @@ export const options: ApplicationCommandOptionData[] = [
     description: "Command to retrieve help for",
   },
 ];
-export async function call(message: Message, parts: string[]): Promise<void> {
-  const search = parts.map((s) => new RegExp(s, "gi"));
+export async function call(context: CommandContext): Promise<void> {
+  const search = context.options().map((s) => new RegExp(s as string, "gi"));
   if (search.length === 0) {
-    await message.channel.send({
+    await context.reply({
       embeds: [
         new MessageEmbed({
           title: "Help",
           color: EMBED_COLOR,
           description:
             "[More detailed documentation here](https://gamestatus.douile.com/docs/user)\n" +
-            Array.from(message.client.commands.entries())
+            Array.from(context.client().commands.entries())
               .filter((cmd) =>
-                cmd[0] !== "help" && cmd[1].check ? cmd[1].check(message) : true
+                cmd[0] !== "help" && cmd[1].check ? cmd[1].check(context) : true
               )
-              .map((cmd) => `\`${message.client.config.prefix}${cmd[0]}\``)
+              .map((cmd) => `\`${context.client().config.prefix}${cmd[0]}\``)
               .join("\n"),
           footer: {
-            text: `Use "${message.client.config.prefix}help commandName" for detailed help`,
+            text: `Use "${
+              context.client().config.prefix
+            }help commandName" for detailed help`,
           },
         }),
       ],
+      ephemeral: true,
     });
   } else {
-    await message.channel.send({
+    await context.reply({
       embeds: [
         new MessageEmbed({
           title: "Help",
           color: EMBED_COLOR,
           description:
             "[More detailed documentation here](https://gamestatus.douile.com/docs/user)",
-          fields: Array.from(message.client.commands.entries())
+          fields: Array.from(context.client().commands.entries())
             .filter(
               (cmd) =>
-                matchAny(`${message.client.config.prefix}${cmd[0]}`, search) &&
-                (cmd[1].check ? cmd[1].check(message) : true)
+                matchAny(
+                  `${context.client().config.prefix}${cmd[0]}`,
+                  search
+                ) && (cmd[1].check ? cmd[1].check(context) : true)
             )
             .map((cmd) => {
               return {
-                name: `${message.client.config.prefix}${cmd[0]}`,
+                name: `${context.client().config.prefix}${cmd[0]}`,
                 value:
                   typeof cmd[1].help === "string"
                     ? cmd[1].help
@@ -84,6 +89,7 @@ export async function call(message: Message, parts: string[]): Promise<void> {
             }),
         }),
       ],
+      ephemeral: true,
     });
   }
 }

--- a/src/commands/limits.ts
+++ b/src/commands/limits.ts
@@ -15,19 +15,20 @@ GNU General Public License for more details.
 
 import { MessageEmbed } from "discord.js-light";
 
-import Message from "../structs/Message";
 import { getLimits, getUserLimits } from "../limits";
 import { EMBED_COLOR } from "../constants";
+import { CommandContext } from "../structs/CommandContext";
 
 export const name = "limits";
 export const help = "View your guild/channel limits";
 
-export async function call(message: Message): Promise<void> {
-  const limits = message.guild
-    ? await getLimits(message.client, message.guild, true)
-    : await getUserLimits(message.client, message.author.id, true);
-  const user = await message.client.users.fetch(limits.user);
-  await message.channel.send({
+export async function call(context: CommandContext): Promise<void> {
+  const guild = context.guild();
+  const limits = guild
+    ? await getLimits(context.client(), guild, true)
+    : await getUserLimits(context.client(), context.user().id, true);
+  const user = await context.client().users.fetch(limits.user);
+  await context.reply({
     embeds: [
       new MessageEmbed({
         author: {
@@ -40,5 +41,6 @@ export async function call(message: Message): Promise<void> {
         color: EMBED_COLOR,
       }),
     ],
+    ephemeral: true,
   });
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -60,7 +60,7 @@ interface StatusOptionsError {
 function getParameters(
   context: GuildCommandContext
 ): StatusOptions | StatusOptionsError {
-  console.log('getParams', context);
+  console.log("getParams", context);
   if (context instanceof MessageContext) {
     const parts = context.options().filter((s) => s.length > 0);
     if (parts.length < 2) {
@@ -103,7 +103,9 @@ export async function call(context: CommandContext): Promise<void> {
 
   if (!isValidGame(parameters.game)) {
     await context.reply({
-      content: `\`${parameters.game}\` is not a valid game please check \`${context.client().config.prefix}gamelist\``,
+      content: `\`${parameters.game}\` is not a valid game please check \`${
+        context.client().config.prefix
+      }gamelist\``,
       ephemeral: true,
     });
     return;
@@ -111,7 +113,7 @@ export async function call(context: CommandContext): Promise<void> {
 
   // Check channel permissions
   const channel = context.channel();
-  if (!channel) throw new Error('No channel');
+  if (!channel) throw new Error("No channel");
   const updateCache = context.updateCache();
 
   const update = new Update(
@@ -136,14 +138,14 @@ export async function call(context: CommandContext): Promise<void> {
     if (updateMessage) await updateMessage.delete();
     // No need to delete as update isn't in database yet
     await context.reply({
-      content: `The server (\`${parameters.host}\`) was offline or unreachable`
+      content: `The server (\`${parameters.host}\`) was offline or unreachable`,
     });
     return;
   }
   await updateCache.create(update);
   update._dontAutoSave = false;
   await context.reply({
-    content: 'Status created',
+    content: "Status created",
     ephemeral: true,
   });
   verboseLog(`[C/status] Created update ${update.ID()}`);

--- a/src/commands/statusclear.ts
+++ b/src/commands/statusclear.ts
@@ -1,6 +1,6 @@
 /*
 discord-gamestatus: Game server monitoring via discord API
-Copyright (C) 2019-2021 Douile
+Copyright (C) 2019-2022 Douile
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -15,16 +15,19 @@ GNU General Public License for more details.
 
 import { TextChannel } from "discord.js-light";
 
-import Message from "../structs/Message";
 import { isAdmin } from "../checks";
+import { CommandContext } from "../structs/CommandContext";
 import { channelFirstArg } from "../utils";
 
 export const name = "statusclear";
 export const check = isAdmin;
 export const help = "Clear all status messages from the channel";
 
-export async function call(message: Message, args: string[]): Promise<void> {
-  const response = await message.channel.send("Clearing status updates...");
+export async function call(context: CommandContext): Promise<void> {
+  const response = await context.reply({
+    content: "Clearing status updates...",
+    ephemeral: true,
+  });
   let channel;
   try {
     channel = await channelFirstArg(message, args);

--- a/src/commands/statusclear.ts
+++ b/src/commands/statusclear.ts
@@ -13,10 +13,14 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 */
 
-import { TextChannel } from "discord.js-light";
+import { GuildChannel } from "discord.js";
 
 import { isAdmin } from "../checks";
-import { CommandContext } from "../structs/CommandContext";
+import {
+  CommandContext,
+  CommandInteractionContext,
+  MessageContext,
+} from "../structs/CommandContext";
 import { channelFirstArg } from "../utils";
 
 export const name = "statusclear";
@@ -24,25 +28,36 @@ export const check = isAdmin;
 export const help = "Clear all status messages from the channel";
 
 export async function call(context: CommandContext): Promise<void> {
+  const guildContext = context.intoGuildContext();
+  if (!guildContext) return;
+
+  let channel;
+  if (guildContext instanceof MessageContext) {
+    channel = await channelFirstArg(
+      guildContext.inner(),
+      guildContext.options()
+    );
+  } else if (guildContext instanceof CommandInteractionContext) {
+    channel = guildContext.channel();
+  } else {
+    throw new Error("unreachable");
+  }
+
+  if (!channel || channel.type === "DM") { 
+    return;
+  };
+
   const response = await context.reply({
     content: "Clearing status updates...",
     ephemeral: true,
   });
-  let channel;
-  try {
-    channel = await channelFirstArg(message, args);
-  } catch {
-    return;
-  }
 
-  if (!channel || !(channel instanceof TextChannel)) return;
-
-  const updates = await message.client.updateCache.get({
+  const updates = await context.updateCache().get({
     channel: channel.id,
     guild: channel.guild.id,
   });
   for (const update of updates) {
-    const msg = await update.getMessage(message.client);
+    const msg = await update.getMessage(context.client());
     if (msg) {
       try {
         await msg.delete();
@@ -52,9 +67,10 @@ export async function call(context: CommandContext): Promise<void> {
     }
   }
 
-  const count = await message.client.updateCache.delete({
-    guild: channel?.guild?.id,
-    channel: channel?.id,
+  const count = await context.updateCache().delete({
+    guild: channel.guild.id,
+    channel: channel.id,
   });
-  await response.edit(`${count} Status updates have been cleared`);
+  // FIXME: We should check when we can't edit the response
+  await response?.edit(`${count} Status updates have been cleared`);
 }

--- a/src/commands/statusclear.ts
+++ b/src/commands/statusclear.ts
@@ -43,9 +43,9 @@ export async function call(context: CommandContext): Promise<void> {
     throw new Error("unreachable");
   }
 
-  if (!channel || channel.type === "DM") { 
+  if (!channel || channel.type === "DM") {
     return;
-  };
+  }
 
   const response = await context.reply({
     content: "Clearing status updates...",

--- a/src/commands/statusmod.ts
+++ b/src/commands/statusmod.ts
@@ -26,8 +26,8 @@ import { EMBED_COLOR, FORMAT_PROPERTIES } from "../constants";
 import {
   CommandContext,
   GuildCommandContext,
-  GuildCommandInteractionContext,
-  GuildMessageContext,
+  CommandInteractionContext,
+  MessageContext,
 } from "../structs/CommandContext";
 import { warnLog } from "../debug";
 
@@ -181,11 +181,11 @@ interface ErrorOptions {
 
 function parseOptions(context: GuildCommandContext): Options {
   try {
-    if (context instanceof GuildMessageContext) {
+    if (context instanceof MessageContext) {
       return parseOptionsFromMessage(context);
     }
 
-    if (context instanceof GuildCommandInteractionContext) {
+    if (context instanceof CommandInteractionContext) {
       return parseOptionsFromCommandInteraction(context);
     }
   } catch (e) {
@@ -199,7 +199,7 @@ function parseOptions(context: GuildCommandContext): Options {
   throw new Error("unreachable");
 }
 
-function parseOptionsFromMessage(context: GuildMessageContext): Options {
+function parseOptionsFromMessage(context: MessageContext): Options {
   const args = context.options();
 
   if (args.length === 0) return { mode: "list" };
@@ -217,7 +217,7 @@ function parseOptionsFromMessage(context: GuildMessageContext): Options {
 }
 
 function parseOptionsFromCommandInteraction(
-  context: GuildCommandInteractionContext
+  context: CommandInteractionContext
 ): Options {
   const opts = context.inner().options;
 

--- a/src/commands/statusmod.ts
+++ b/src/commands/statusmod.ts
@@ -19,11 +19,17 @@ import {
   MessageEmbed,
 } from "discord.js-light";
 
-import Message from "../structs/Message";
 import Update from "../structs/Update";
 import { isAdmin } from "../checks";
 import { UpdateOptions } from "../structs/Update/UpdateOptions";
 import { EMBED_COLOR, FORMAT_PROPERTIES } from "../constants";
+import {
+  CommandContext,
+  GuildCommandContext,
+  GuildCommandInteractionContext,
+  GuildMessageContext,
+} from "../structs/CommandContext";
+import { warnLog } from "../debug";
 
 const WARNING =
   "_Changes will not take effect until after the status has updated_";
@@ -69,6 +75,11 @@ const OPTION_CHOICES: ApplicationCommandOptionChoiceData[] =
   OPTION_LAYOUT.filter((o) => o !== "spacer").map((o) => {
     return { name: o, value: o };
   });
+const KEYS = {
+  id: "status-id",
+  key: "setting",
+  value: "value",
+};
 export const options: ApplicationCommandOptionData[] = [
   {
     type: "SUB_COMMAND",
@@ -82,7 +93,7 @@ export const options: ApplicationCommandOptionData[] = [
     options: [
       {
         type: "INTEGER",
-        name: "status-id",
+        name: KEYS.id,
         description: "ID of the status message",
         required: true,
         minValue: 0,
@@ -96,14 +107,14 @@ export const options: ApplicationCommandOptionData[] = [
     options: [
       {
         type: "INTEGER",
-        name: "status-id",
+        name: KEYS.id,
         description: "ID of the status message",
         required: true,
         minValue: 0,
       },
       {
         type: "STRING",
-        name: "setting",
+        name: KEYS.key,
         description: "Setting to reset",
         required: true,
         choices: OPTION_CHOICES,
@@ -117,21 +128,21 @@ export const options: ApplicationCommandOptionData[] = [
     options: [
       {
         type: "INTEGER",
-        name: "status-id",
+        name: KEYS.id,
         description: "ID of the status message",
         required: true,
         minValue: 0,
       },
       {
         type: "STRING",
-        name: "setting",
+        name: KEYS.key,
         description: "Setting to set",
         required: true,
         choices: OPTION_CHOICES,
       },
       {
         type: "STRING",
-        name: "value",
+        name: KEYS.value,
         description: "New value of the setting",
         required: true,
       },
@@ -139,13 +150,119 @@ export const options: ApplicationCommandOptionData[] = [
   },
 ];
 
-export async function call(message: Message): Promise<void> {
-  const args = message.content.split(" ").splice(1);
+type Options =
+  | ListOptions
+  | ViewOptions
+  | ResetOptions
+  | SetOptions
+  | ErrorOptions;
+interface ListOptions {
+  mode: "list";
+}
+interface ViewOptions {
+  mode: "view";
+  index: number;
+}
+interface ResetOptions {
+  mode: "reset";
+  index: number;
+  key: string;
+}
+interface SetOptions {
+  mode: "set";
+  index: number;
+  key: string;
+  value: string;
+}
+interface ErrorOptions {
+  mode: "error";
+  message: string;
+}
 
-  if (!message.guild) return;
+function parseOptions(context: GuildCommandContext): Options {
+  try {
+    if (context instanceof GuildMessageContext) {
+      return parseOptionsFromMessage(context);
+    }
 
-  let statuses = await message.client.updateCache.get({
-    guild: message.guild.id,
+    if (context instanceof GuildCommandInteractionContext) {
+      return parseOptionsFromCommandInteraction(context);
+    }
+  } catch (e) {
+    warnLog(`Error parsing command "${name}"`, e);
+    return {
+      mode: "error",
+      message: "Unexpected error parsing command options",
+    };
+  }
+
+  throw new Error("unreachable");
+}
+
+function parseOptionsFromMessage(context: GuildMessageContext): Options {
+  const args = context.options();
+
+  if (args.length === 0) return { mode: "list" };
+
+  const index = parseInt(args[0].replace(/^#/, ""));
+  if (isNaN(index))
+    return { mode: "error", message: "Status index must be an integer" };
+  if (args.length === 1) return { mode: "view", index };
+
+  const key = args[1].trim();
+  if (args.length === 2) return { mode: "reset", index, key };
+
+  const value = args.slice(2).join(" ");
+  return { mode: "set", index, key, value };
+}
+
+function parseOptionsFromCommandInteraction(
+  context: GuildCommandInteractionContext
+): Options {
+  const opts = context.inner().options;
+
+  const command = opts.getSubcommand(true);
+
+  // List
+  if (command === options[0].name) return { mode: "list" };
+
+  // Get
+  const index = opts.getInteger(KEYS.id, true);
+  if (command === options[1].name) {
+    return { mode: "view", index };
+  }
+
+  // Reset
+  const key = opts.getString(KEYS.key, true);
+  if (command === options[2].name) {
+    return { mode: "reset", index, key };
+  }
+
+  // Set
+  const value = opts.getString(KEYS.value, true);
+  if (command === options[3].name) {
+    return { mode: "set", index, key, value };
+  }
+
+  throw new Error("unreachable");
+}
+
+export async function call(context: CommandContext): Promise<void> {
+  const guildContext = context.intoGuildContext();
+  if (!guildContext) return;
+
+  const options = parseOptions(guildContext);
+
+  if (options.mode === "error") {
+    await context.reply({
+      content: `Error: ${options.message}`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  let statuses = await context.client().updateCache.get({
+    guild: guildContext.guild().id,
   });
   if (statuses === undefined) {
     statuses = [];
@@ -153,96 +270,7 @@ export async function call(message: Message): Promise<void> {
     statuses = [statuses];
   }
 
-  if (args.length > 0) {
-    const index = parseInt(args[0].replace(/^#/, ""));
-    if (!isNaN(index) && index < statuses.length && index >= 0) {
-      const status = statuses[index];
-      if (args.length === 1) {
-        const opts = status.getOptions();
-        const options = [];
-        for (const fieldName of OPTION_LAYOUT) {
-          if (fieldName === "spacer") {
-            options.push({ name: "_ _", value: "_ _", inline: false });
-          } else {
-            options.push({
-              name: fieldName,
-              value: `\`\`\`json\n${JSON.stringify(opts[fieldName])}\n\`\`\``,
-              inline: true,
-            });
-          }
-        }
-
-        await message.channel.send({
-          embeds: [
-            new MessageEmbed({
-              title: `#${index}`,
-              description: statusIdentity(status),
-              fields: options,
-              timestamp: Date.now(),
-              color: EMBED_COLOR,
-            }),
-          ],
-        });
-      } else if (args.length === 2) {
-        await status.deleteOption(
-          message.client,
-          args[1] as keyof UpdateOptions
-        );
-        await message.channel.send({
-          embeds: [
-            new MessageEmbed({
-              title: `#${index}`,
-              description: `${statusIdentity(status)}\nReset: \`${
-                args[1]
-              }\`\n${WARNING}`,
-              timestamp: Date.now(),
-              color: EMBED_COLOR,
-            }),
-          ],
-        });
-      } else {
-        const value = args.splice(2).join(" ");
-        let error;
-        try {
-          await status.setOption(
-            message.client,
-            args[1] as keyof UpdateOptions,
-            value
-          );
-        } catch (e) {
-          error = e;
-          console.error("Error setting option", error);
-        }
-
-        await message.channel.send({
-          embeds: [
-            new MessageEmbed({
-              title: `#${index}`,
-              description: `${statusIdentity(status)}\nSet: \`${
-                args[1]
-              }=${status.getOption(
-                args[1] as keyof UpdateOptions
-              )}\`\n${WARNING}`,
-              timestamp: Date.now(),
-              color: EMBED_COLOR,
-            }),
-          ],
-        });
-      }
-    } else {
-      if (statuses.length === 0) {
-        await message.channel.send(
-          `There are no status messages in this guild`
-        );
-      } else {
-        await message.channel.send(
-          `Please enter a valid status ID (between 0 and ${
-            statuses.length - 1
-          })`
-        );
-      }
-    }
-  } else {
+  if (options.mode === "list") {
     const fields = statuses.map((status: Update, i: number) => {
       return {
         name: `#${i}`,
@@ -250,7 +278,8 @@ export async function call(message: Message): Promise<void> {
         inline: false,
       };
     });
-    await message.channel.send({
+
+    await context.reply({
       embeds: [
         new MessageEmbed({
           title: `${fields.length} Active statuses`,
@@ -259,6 +288,89 @@ export async function call(message: Message): Promise<void> {
           color: EMBED_COLOR,
         }),
       ],
+      ephemeral: true,
     });
+    return;
+  }
+
+  const status = statuses[options.index];
+  if (options.mode === "view") {
+    const opts = status.getOptions();
+    const outputOptions = [];
+    for (const fieldName of OPTION_LAYOUT) {
+      if (fieldName === "spacer") {
+        outputOptions.push({ name: "_ _", value: "_ _", inline: false });
+      } else {
+        outputOptions.push({
+          name: fieldName,
+          value: `\`\`\`json\n${JSON.stringify(opts[fieldName])}\n\`\`\``,
+          inline: true,
+        });
+      }
+    }
+
+    await context.reply({
+      embeds: [
+        new MessageEmbed({
+          title: `#${options.index}`,
+          description: statusIdentity(status),
+          fields: outputOptions,
+          timestamp: Date.now(),
+          color: EMBED_COLOR,
+        }),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (options.mode === "reset") {
+    await status.deleteOption(
+      context.client(),
+      options.key as keyof UpdateOptions
+    );
+    await context.reply({
+      embeds: [
+        new MessageEmbed({
+          title: `#${options.index}`,
+          description: `${statusIdentity(status)}\nReset: \`${
+            options.key
+          }\`\n${WARNING}`,
+          timestamp: Date.now(),
+          color: EMBED_COLOR,
+        }),
+      ],
+    });
+    return;
+  }
+
+  if (options.mode === "set") {
+    let error;
+    try {
+      await status.setOption(
+        context.client(),
+        options.key as keyof UpdateOptions,
+        options.value
+      );
+    } catch (e) {
+      error = e;
+      console.error("Error setting option", error);
+    }
+
+    await context.reply({
+      embeds: [
+        new MessageEmbed({
+          title: `#${options.index}`,
+          description: `${statusIdentity(status)}\nSet: \`${
+            options.key
+          }=${status.getOption(
+            options.key as keyof UpdateOptions
+          )}\`\n${WARNING}`,
+          timestamp: Date.now(),
+          color: EMBED_COLOR,
+        }),
+      ],
+    });
+    return;
   }
 }

--- a/src/commands/tickdebug.ts
+++ b/src/commands/tickdebug.ts
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 import { isBotOwner } from "../checks";
 import { EMBED_COLOR } from "../constants";
 import { asyncArray } from "../utils";
-import {CommandContext} from "../structs/CommandContext";
+import { CommandContext } from "../structs/CommandContext";
 
 export const name = "tickdebug";
 export const check = isBotOwner;

--- a/src/commands/tickdebug.ts
+++ b/src/commands/tickdebug.ts
@@ -13,20 +13,23 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 */
 
-import Message from "../structs/Message";
 import { isBotOwner } from "../checks";
 import { EMBED_COLOR } from "../constants";
 import { asyncArray } from "../utils";
+import {CommandContext} from "../structs/CommandContext";
 
 export const name = "tickdebug";
 export const check = isBotOwner;
 export const help = "Debug status updates`";
+export const disableSlash = true;
 
-export async function call(message: Message): Promise<void> {
+export async function call(context: CommandContext): Promise<void> {
+  const config = context.client().config;
+
   let i = 0;
   let total = 0;
   const ticks = await asyncArray(
-    message.client.updateCache.tickIterable(message.client.config.tickCount)
+    context.updateCache().tickIterable(config.tickCount)
   );
   const tickList = Array.from(ticks)
     .map((tick) => {
@@ -34,10 +37,10 @@ export async function call(message: Message): Promise<void> {
       return `${i++}: ${tick.length}`;
     })
     .join("\n");
-  await message.channel.send({
+  await context.reply({
     embeds: [
       {
-        title: `Ticks: ${message.client.config.tickCount}`,
+        title: `Ticks: ${config.tickCount}`,
         description: `Total updates: ${total}\nAverage updates per tick: ${
           Math.round((total / i) * 1e3) / 1e3
         }\n\`\`\`\n${tickList}\`\`\``,

--- a/src/structs/Command.ts
+++ b/src/structs/Command.ts
@@ -20,5 +20,6 @@ export default interface Command {
   name: string;
   help?: string;
   check?: Check;
+  disableSlash?: boolean;
   call: (context: CommandContext) => Promise<void>;
 }

--- a/src/structs/Command.ts
+++ b/src/structs/Command.ts
@@ -13,12 +13,12 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 */
 
-import Message from "./Message";
+import { CommandContext } from "./CommandContext";
 import { Check } from "../checks";
 
 export default interface Command {
   name: string;
   help?: string;
   check?: Check;
-  call: (message?: Message, parts?: string[]) => Promise<void>;
+  call: (context: CommandContext) => Promise<void>;
 }

--- a/src/structs/CommandContext.ts
+++ b/src/structs/CommandContext.ts
@@ -93,7 +93,7 @@ export class CommandInteractionContext implements CommandContext {
 
   intoGuildContext(): GuildCommandInteractionContext | null {
     if (this.data.member && this.data.guild)
-      return this as GuildCommandInteractionContext;
+      return GuildCommandInteractionContext.fromCommandInteractionContext(this);
     return null;
   }
 
@@ -106,6 +106,11 @@ export class GuildCommandInteractionContext
   extends CommandInteractionContext
   implements GuildCommandInteractionContext
 {
+  static fromCommandInteractionContext(
+    context: CommandInteractionContext
+  ): GuildCommandInteractionContext {
+    return new GuildCommandInteractionContext(context.inner());
+  }
   member() {
     return this.data.member as GuildMember;
   }
@@ -167,7 +172,8 @@ export class MessageContext implements CommandContext {
   }
 
   intoGuildContext(): GuildMessageContext | null {
-    if (this.data.member && this.data.guild) return this as GuildMessageContext;
+    if (this.data.member && this.data.guild)
+      return GuildMessageContext.fromMessageContext(this);
     return null;
   }
 
@@ -180,6 +186,14 @@ export class GuildMessageContext
   extends MessageContext
   implements GuildCommandContext
 {
+  static fromMessageContext(context: MessageContext): GuildMessageContext {
+    return new GuildMessageContext(
+      context.inner(),
+      context.command(),
+      context.options()
+    );
+  }
+
   member() {
     return this.data.member as GuildMember;
   }

--- a/src/structs/CommandContext.ts
+++ b/src/structs/CommandContext.ts
@@ -96,6 +96,10 @@ export class CommandInteractionContext implements CommandContext {
       return this as GuildCommandInteractionContext;
     return null;
   }
+
+  inner(): CommandInteraction {
+    return this.data;
+  }
 }
 
 export class GuildCommandInteractionContext

--- a/src/structs/CommandContext.ts
+++ b/src/structs/CommandContext.ts
@@ -20,12 +20,12 @@ export interface ReplyOptions {
   ephemeral?: boolean;
 }
 
-export type OptionType = number | string | boolean | undefined;
+//export type OptionType = number | string | boolean | undefined;
+export type OptionType = string;
 
 export interface CommandContext {
   reply: (options: ReplyOptions) => Promise<Message | void>;
   command: () => string;
-  options: () => OptionType[];
   user: () => User;
   member: () => GuildMember | null;
   guild: () => Guild | null;
@@ -169,6 +169,10 @@ export class MessageContext implements CommandContext {
   intoGuildContext(): GuildMessageContext | null {
     if (this.data.member && this.data.guild) return this as GuildMessageContext;
     return null;
+  }
+
+  inner(): Message {
+    return this.data;
   }
 }
 

--- a/src/structs/CommandContext.ts
+++ b/src/structs/CommandContext.ts
@@ -1,0 +1,182 @@
+import {
+  CommandInteraction,
+  Guild,
+  GuildMember,
+  InteractionReplyOptions,
+  Message,
+  MessageEmbed,
+  ReplyMessageOptions,
+  TextBasedChannel,
+  User,
+} from "discord.js-light";
+import { APIEmbed } from "discord-api-types/v10";
+import Client from "./Client";
+import SaveInterface from "./save/SaveInterface";
+import UpdateCache from "./UpdateCache";
+
+export interface ReplyOptions {
+  content?: string;
+  embeds?: MessageEmbed[] | APIEmbed[];
+  ephemeral?: boolean;
+}
+
+export type OptionType = number | string | boolean | undefined;
+
+export interface CommandContext {
+  reply: (options: ReplyOptions) => Promise<Message | void>;
+  command: () => string;
+  options: () => OptionType[];
+  user: () => User;
+  member: () => GuildMember | null;
+  guild: () => Guild | null;
+  channel: () => TextBasedChannel | null;
+
+  client: () => Client;
+  updateCache: () => UpdateCache;
+  saveInterface: () => SaveInterface;
+
+  intoGuildContext: () => GuildCommandContext | null;
+}
+
+export interface GuildCommandContext extends CommandContext {
+  member: () => GuildMember;
+  guild: () => Guild;
+}
+
+export class CommandInteractionContext implements CommandContext {
+  protected data: CommandInteraction;
+
+  constructor(interaction: CommandInteraction) {
+    this.data = interaction;
+  }
+
+  reply(options: InteractionReplyOptions) {
+    return this.data.reply(options);
+  }
+
+  command() {
+    return this.data.commandName;
+  }
+
+  options() {
+    return this.data.options.data.map((v) => v.value);
+  }
+
+  user() {
+    return this.data.user;
+  }
+
+  member() {
+    // FIXME: Types
+    return this.data.member as GuildMember | null;
+  }
+
+  guild() {
+    return this.data.guild;
+  }
+
+  channel() {
+    return this.data.channel;
+  }
+
+  client() {
+    return this.data.client as Client;
+  }
+
+  updateCache() {
+    return this.client().updateCache;
+  }
+
+  saveInterface() {
+    return this.updateCache().saveInterface;
+  }
+
+  intoGuildContext(): GuildCommandInteractionContext | null {
+    if (this.data.member && this.data.guild)
+      return this as GuildCommandInteractionContext;
+    return null;
+  }
+}
+
+export class GuildCommandInteractionContext
+  extends CommandInteractionContext
+  implements GuildCommandInteractionContext
+{
+  member() {
+    return this.data.member as GuildMember;
+  }
+
+  guild() {
+    return this.data.guild as Guild;
+  }
+}
+
+export class MessageContext implements CommandContext {
+  protected data: Message;
+  private commandName: string;
+  private parts: string[];
+
+  constructor(message: Message, commandName: string, parts: string[]) {
+    this.data = message;
+    this.commandName = commandName;
+    this.parts = parts;
+  }
+
+  reply(options: ReplyMessageOptions) {
+    return this.data.reply(options);
+  }
+
+  command() {
+    return this.commandName;
+  }
+
+  options() {
+    return this.parts;
+  }
+
+  user() {
+    return this.data.author;
+  }
+
+  member() {
+    return this.data.member;
+  }
+
+  guild() {
+    return this.data.guild;
+  }
+
+  channel() {
+    return this.data.channel;
+  }
+
+  client() {
+    return this.data.client as Client;
+  }
+
+  updateCache() {
+    return this.client().updateCache;
+  }
+
+  saveInterface() {
+    return this.updateCache().saveInterface;
+  }
+
+  intoGuildContext(): GuildMessageContext | null {
+    if (this.data.member && this.data.guild) return this as GuildMessageContext;
+    return null;
+  }
+}
+
+export class GuildMessageContext
+  extends MessageContext
+  implements GuildCommandContext
+{
+  member() {
+    return this.data.member as GuildMember;
+  }
+
+  guild() {
+    return this.data.guild as Guild;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,12 @@ import { is } from "@douile/bot-utilities";
 
 import { Message, TextBasedChannel } from "discord.js-light";
 
+import {
+  CommandContext,
+  MessageContext,
+  CommandInteractionContext,
+} from "./structs/CommandContext";
+
 export async function channelFirstArg(
   message: Message,
   args: string[]
@@ -72,4 +78,24 @@ export async function asyncArray<T>(
  */
 export function assign<T, U>(target: T, source: U): asserts target is T & U {
   Object.assign(target, source);
+}
+
+/**
+ * Convert a context into search fields
+ */
+export function getSearch(
+  context: CommandContext,
+  optionName: string,
+  flags = "i"
+): RegExp[] {
+  if (context instanceof MessageContext) {
+    return context.options().length > 0
+      ? context.options().map((s) => new RegExp(s, flags))
+      : [];
+  }
+  if (context instanceof CommandInteractionContext) {
+    const search = context.inner().options.getString(optionName, false);
+    return search ? search.split(" ").map((s) => new RegExp(s, "i")) : [];
+  }
+  throw new Error("unreachable");
 }


### PR DESCRIPTION
Add support for slash commands for all commands.

This introduces the CommandContext type which allows command handlers to interact with either a message or a command interaction without needing separate functions (except for option parsing in some cases).

All current commands have been converted to work with the new CommandContext